### PR TITLE
Switch Matrix rain to WebGL2 GPU renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Matrix Falling Code Effect 🌌
 
-This project recreates the **Matrix-style falling code effect** using **HTML**, **CSS**, and **JavaScript**. No images or external libraries are used—just pure web technologies!
+This project recreates the **Matrix-style falling code effect** using **HTML**, **CSS**, and **WebGL 2**. The animation runs entirely on the GPU for smooth, high-performance rendering.
 
 ---
 
 ### 🎥 **Demo**
-> Experience the effect live by opening the `index.html` file in any modern browser.
+> Experience the effect live by opening the `index.html` file in any modern browser with WebGL 2 support.
 
 ---
 
@@ -16,8 +16,8 @@ The project contains the following files:
 ```plaintext
 matrix-falling-code/
 │
-├── index.html   # Main HTML file with the <canvas> element
-├── matrix.js    # JavaScript file for the animation logic
+├── index.html   # Main HTML file with the WebGL canvas
+├── matrix.js    # JavaScript file for the WebGL shader animation
 └── README.md    # Project documentation
 ```
 
@@ -43,11 +43,9 @@ Follow these steps to run the project locally:
 
 ### 🛠️ **How It Works**
 
-1. A `<canvas>` element is used to render characters dynamically.
-2. The **JavaScript** file (`matrix.js`) generates random characters and animates their fall using:
-   - Green text with a trailing effect.
-   - A smooth animation loop using `requestAnimationFrame`.
-3. The **CSS** ensures a black background and full-screen canvas.
+1. A single `<canvas>` element is used for rendering.
+2. A **WebGL 2 fragment shader** generates falling glyphs, trails, and head glow entirely on the GPU.
+3. The JavaScript file (`matrix.js`) handles resize events, animation timing, and pause controls.
 
 ---
 
@@ -55,9 +53,9 @@ Follow these steps to run the project locally:
 
 You can customize the following settings in `matrix.js`:
 
-- **Characters**: Modify the `matrixChars` string to use different symbols.
-- **Font Size**: Adjust the `fontSize` variable to increase or decrease the text size.
-- **Speed**: Change the drop speed by tweaking the `Math.random()` threshold.
+- **Glyph density**: Adjust the `columns` and `cellRows` values in the shader.
+- **Speed**: Update the `speed` mix range in the shader for faster or slower rain.
+- **Color**: Modify the `color` vector in the fragment shader.
 
 ---
 
@@ -83,4 +81,4 @@ This project is open-source and available under the [MIT License](LICENSE).
 ### 🔗 **Author**
 
 **Andres Zenteno**  
-GitHub: [@andresz74](https://github.com/andresz74)  
+GitHub: [@andresz74](https://github.com/andresz74)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Matrix Falling Code Effect 🌌
 
-This project recreates the **Matrix-style falling code effect** using **HTML**, **CSS**, and **WebGL 2**. The animation runs entirely on the GPU for smooth, high-performance rendering.
+This project recreates the **Matrix-style falling code effect** using **HTML**, **CSS**, and **WebGL 2**. The animation runs entirely on the GPU for smooth, high-performance rendering while preserving the original Latin + Japanese glyph set.
 
 ---
 
@@ -53,7 +53,7 @@ Follow these steps to run the project locally:
 
 You can customize the following settings in `matrix.js`:
 
-- **Glyph density**: Adjust the `columns` and `cellRows` values in the shader.
+- **Glyph density**: Adjust the `columns` and `rows` values in the shader.
 - **Speed**: Update the `speed` mix range in the shader for faster or slower rain.
 - **Color**: Modify the `color` vector in the fragment shader.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Follow these steps to run the project locally:
 You can customize the following settings in `matrix.js`:
 
 - **Glyph density**: Adjust the `columns` and `rows` values in the shader for each depth layer.
+- **Depth styling**: Tune per-layer `speed` ranges and the `blurStrength` to emphasize foreground vs. background separation.
 - **Speed**: Update the `speed` mix range in the shader for faster or slower rain.
 - **Color**: Modify the `color` vector in the fragment shader.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Follow these steps to run the project locally:
 ### 🛠️ **How It Works**
 
 1. A single `<canvas>` element is used for rendering.
-2. A **WebGL 2 fragment shader** generates falling glyphs, trails, and head glow entirely on the GPU.
+2. A **WebGL 2 fragment shader** generates falling glyphs, trails, and head glow entirely on the GPU with multiple depth layers.
 3. The JavaScript file (`matrix.js`) handles resize events, animation timing, and pause controls.
 
 ---
@@ -53,7 +53,7 @@ Follow these steps to run the project locally:
 
 You can customize the following settings in `matrix.js`:
 
-- **Glyph density**: Adjust the `columns` and `rows` values in the shader.
+- **Glyph density**: Adjust the `columns` and `rows` values in the shader for each depth layer.
 - **Speed**: Update the `speed` mix range in the shader for faster or slower rain.
 - **Color**: Modify the `color` vector in the fragment shader.
 

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Facebook Meta Tags -->
-    <meta property="og:title" content="Matrix Falling Code with Multi-Layered Canvases" />
+    <meta property="og:title" content="Matrix Falling Code with WebGL" />
     <meta property="og:description"
-        content="Create a visually stunning Matrix rain animation using HTML5 Canvas, JavaScript, and CSS. Add gradients, unique trails, and interactive effects to bring your code to life!" />
+        content="Experience a GPU-driven Matrix rain animation powered by WebGL." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://matrix.andreszenteno.com" />
     <meta property="og:image" content="https://zenteno.org/public_assets/matrix-rain-2.png" />
@@ -18,12 +18,12 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta property="twitter:domain" content="matrix.andreszenteno.com">
     <meta property="twitter:url" content="https://matrix.andreszenteno.com">
-    <meta name="twitter:title" content="Matrix Falling Code with Multi-Layered Canvases">
-    <meta name="twitter:description" content="Create a visually stunning Matrix rain animation using HTML5 Canvas, JavaScript, and CSS. Add gradients, unique trails, and interactive effects to bring your code to life!">
+    <meta name="twitter:title" content="Matrix Falling Code with WebGL">
+    <meta name="twitter:description" content="Experience a GPU-driven Matrix rain animation powered by WebGL.">
     <meta name="twitter:image" content="https://zenteno.org/public_assets/matrix-rain-2.png">
-    <meta name="description" content="Experience a Matrix-style falling code animation built with HTML5 Canvas, CSS, and JavaScript.">
+    <meta name="description" content="Experience a Matrix-style falling code animation built with WebGL.">
 
-    <title>Matrix Falling Code with Multi-Layered Canvases</title>
+    <title>Matrix Falling Code with WebGL</title>
     <style>
         body,
         html {
@@ -31,45 +31,34 @@
             padding: 0;
             overflow: hidden;
             background-color: black;
+            color: #9cff9c;
+            font-family: "Courier New", monospace;
         }
 
-        /* Stack canvases on top of each other */
         canvas {
             position: absolute;
-            top: 0;
-            left: 0;
+            inset: 0;
             width: 100%;
             height: 100%;
             display: block;
         }
 
-        .blur {
-            filter: blur(4px);
-            transition: filter 0.5s ease-in-out;
-        }
-
-        .opacity-4 {
-            opacity: 0.4;
-            transition: opacity 0.5s ease-in-out;
-        }
-
-        .opacity-8 {
-            opacity: 0.8;
-            transition: opacity 0.5s ease-in-out;
+        #status {
+            position: absolute;
+            top: 16px;
+            left: 16px;
+            z-index: 1;
+            font-size: 14px;
+            max-width: 320px;
+            line-height: 1.4;
         }
     </style>
 </head>
 
 <body>
     <noscript>This animation requires JavaScript to run. Please enable JavaScript in your browser.</noscript>
-    <!-- First Layer -->
-    <canvas id="matrixCanvas1"></canvas>
-    <!-- Second Layer -->
-    <canvas id="matrixCanvas2" class="opacity-4"></canvas>
-    <!-- Third Layer -->
-    <canvas id="matrixCanvas3" class="blur opacity-4"></canvas>
-    <!-- Foreground Canvas -->
-    <canvas id="overlayCanvas" class="blur opacity-4"></canvas>
+    <div id="status" aria-live="polite"></div>
+    <canvas id="matrixCanvas"></canvas>
     <script src="matrix.js"></script>
 </body>
 

--- a/matrix.js
+++ b/matrix.js
@@ -67,7 +67,21 @@ float glyphAlpha(vec2 cellUv, float glyphIndex) {
     return texture(u_glyphAtlas, atlasUv).r;
 }
 
-float layerRain(vec2 centered, float columns, float rows, float speedMin, float speedMax, float intensity, float seedOffset) {
+float glyphAlphaBlur(vec2 cellUv, float glyphIndex, float blurStrength) {
+    if (blurStrength <= 0.0) {
+        return glyphAlpha(cellUv, glyphIndex);
+    }
+    float offset = 0.02 * blurStrength;
+    float base = glyphAlpha(cellUv, glyphIndex) * 0.4;
+    float blur = glyphAlpha(cellUv + vec2(offset, 0.0), glyphIndex);
+    blur += glyphAlpha(cellUv + vec2(-offset, 0.0), glyphIndex);
+    blur += glyphAlpha(cellUv + vec2(0.0, offset), glyphIndex);
+    blur += glyphAlpha(cellUv + vec2(0.0, -offset), glyphIndex);
+    blur = blur * 0.15;
+    return base + blur;
+}
+
+float layerRain(vec2 centered, float columns, float rows, float speedMin, float speedMax, float intensity, float seedOffset, float blurStrength) {
     float columnIndex = floor(centered.x * columns);
     float columnSeed = hash(columnIndex + seedOffset);
     float speed = mix(speedMin, speedMax, columnSeed);
@@ -81,7 +95,7 @@ float layerRain(vec2 centered, float columns, float rows, float speedMin, float 
     vec2 cellUv = vec2(fract(centered.x * columns), fract(centered.y * rows));
     float cellId = floor(centered.y * rows) + columnIndex * 131.0 + seedOffset * 17.0;
     float glyphIndex = floor(hash(cellId) * u_glyphCount);
-    float glyph = glyphAlpha(cellUv, glyphIndex);
+    float glyph = glyphAlphaBlur(cellUv, glyphIndex, blurStrength);
 
     float tail = pow(1.0 - rowPosition, 2.0) * trail;
     float brightness = max(head, tail) * glyph;
@@ -94,9 +108,9 @@ void main() {
     float aspect = u_resolution.x / u_resolution.y;
     vec2 centered = vec2(uv.x * aspect, uv.y);
 
-    float farLayer = layerRain(centered * vec2(1.03, 1.0), 100.0, 80.0, 0.2, 0.8, 0.45, 19.0);
-    float midLayer = layerRain(centered * vec2(1.01, 1.0), 85.0, 65.0, 0.4, 1.1, 0.65, 7.0);
-    float nearLayer = layerRain(centered, 70.0, 50.0, 0.6, 1.6, 1.0, 0.0);
+    float farLayer = layerRain(centered * vec2(1.04, 1.0), 120.0, 95.0, 0.2, 0.7, 0.35, 19.0, 0.0);
+    float midLayer = layerRain(centered * vec2(1.02, 1.0), 90.0, 70.0, 0.5, 1.0, 0.65, 7.0, 1.0);
+    float nearLayer = layerRain(centered, 70.0, 50.0, 0.7, 1.8, 1.0, 0.0, 0.0);
 
     vec3 farColor = vec3(0.0, 0.6, 0.15) * farLayer;
     vec3 midColor = vec3(0.0, 0.8, 0.2) * midLayer;

--- a/matrix.js
+++ b/matrix.js
@@ -67,17 +67,11 @@ float glyphAlpha(vec2 cellUv, float glyphIndex) {
     return texture(u_glyphAtlas, atlasUv).r;
 }
 
-void main() {
-    vec2 uv = gl_FragCoord.xy / u_resolution;
-    float aspect = u_resolution.x / u_resolution.y;
-    vec2 centered = vec2(uv.x * aspect, uv.y);
-
-    float columns = 80.0;
-    float rows = 60.0;
+float layerRain(vec2 centered, float columns, float rows, float speedMin, float speedMax, float intensity, float seedOffset) {
     float columnIndex = floor(centered.x * columns);
-    float columnSeed = hash(columnIndex);
-    float speed = mix(0.3, 1.3, columnSeed);
-    float trail = mix(0.2, 0.8, hash(columnIndex + 42.0));
+    float columnSeed = hash(columnIndex + seedOffset);
+    float speed = mix(speedMin, speedMax, columnSeed);
+    float trail = mix(0.2, 0.8, hash(columnIndex + 42.0 + seedOffset));
 
     float flow = fract(u_time * speed + columnSeed);
     float rowPosition = fract(centered.y + flow);
@@ -85,14 +79,30 @@ void main() {
     float head = smoothstep(0.0, 0.1, rowPosition) * smoothstep(1.0, 0.85, rowPosition);
 
     vec2 cellUv = vec2(fract(centered.x * columns), fract(centered.y * rows));
-    float cellId = floor(centered.y * rows) + columnIndex * 131.0;
+    float cellId = floor(centered.y * rows) + columnIndex * 131.0 + seedOffset * 17.0;
     float glyphIndex = floor(hash(cellId) * u_glyphCount);
     float glyph = glyphAlpha(cellUv, glyphIndex);
 
     float tail = pow(1.0 - rowPosition, 2.0) * trail;
     float brightness = max(head, tail) * glyph;
 
-    vec3 color = vec3(0.0, 0.9, 0.2) * brightness;
+    return brightness * intensity;
+}
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / u_resolution;
+    float aspect = u_resolution.x / u_resolution.y;
+    vec2 centered = vec2(uv.x * aspect, uv.y);
+
+    float farLayer = layerRain(centered * vec2(1.03, 1.0), 100.0, 80.0, 0.2, 0.8, 0.45, 19.0);
+    float midLayer = layerRain(centered * vec2(1.01, 1.0), 85.0, 65.0, 0.4, 1.1, 0.65, 7.0);
+    float nearLayer = layerRain(centered, 70.0, 50.0, 0.6, 1.6, 1.0, 0.0);
+
+    vec3 farColor = vec3(0.0, 0.6, 0.15) * farLayer;
+    vec3 midColor = vec3(0.0, 0.8, 0.2) * midLayer;
+    vec3 nearColor = vec3(0.0, 0.95, 0.25) * nearLayer;
+
+    vec3 color = farColor + midColor + nearColor;
     outColor = vec4(color, 1.0);
 }`;
 

--- a/matrix.js
+++ b/matrix.js
@@ -1,214 +1,173 @@
-// Matrix Rain Characters
-const latinChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()-_=+[]{}|;:',.<>?/`~¡™£¢∞§¶•ªº–≠œ∑´®†¥¨ˆøπ“‘åß∂ƒ©˙∆˚¬Ω≈ç√∫˜µ≤≥÷";
-const japaneseChars = "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん一二三四五六七八九十零";
-const matrixChars = latinChars + japaneseChars;
-const characters = matrixChars.split("");
+const canvas = document.getElementById("matrixCanvas");
+const gl = canvas.getContext("webgl2", { antialias: true });
+const statusEl = document.getElementById("status");
 
+if (!gl) {
+    if (statusEl) {
+        statusEl.textContent = "WebGL2 is required to render the Matrix effect.";
+    }
+    throw new Error("WebGL2 not supported");
+}
 
 const animationState = {
     paused: false,
+    pauseOffset: 0,
+    lastPauseTime: 0,
 };
 
 function togglePause() {
     animationState.paused = !animationState.paused;
+    if (animationState.paused) {
+        animationState.lastPauseTime = performance.now();
+    } else {
+        animationState.pauseOffset += performance.now() - animationState.lastPauseTime;
+    }
 }
 
 function isPaused() {
     return animationState.paused;
 }
 
-// Utility: Set canvas dimensions to window size with devicePixelRatio support
-function resizeCanvas(canvas, ctx = canvas.getContext("2d")) {
+const vertexSource = `#version 300 es
+in vec2 a_position;
+
+void main() {
+    gl_Position = vec4(a_position, 0.0, 1.0);
+}`;
+
+const fragmentSource = `#version 300 es
+precision highp float;
+
+uniform vec2 u_resolution;
+uniform float u_time;
+
+out vec4 outColor;
+
+float hash(float n) {
+    return fract(sin(n) * 43758.5453123);
+}
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float glyph(vec2 cellUv, float seed) {
+    vec2 grid = floor(cellUv * vec2(5.0, 7.0));
+    float index = grid.x + grid.y * 5.0;
+    float bit = step(0.5, hash(vec2(index, seed)));
+    float edge = smoothstep(0.0, 0.08, min(min(cellUv.x, cellUv.y), min(1.0 - cellUv.x, 1.0 - cellUv.y)));
+    return bit * edge;
+}
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / u_resolution;
+    float aspect = u_resolution.x / u_resolution.y;
+    vec2 centered = vec2(uv.x * aspect, uv.y);
+
+    float columns = 80.0;
+    float columnIndex = floor(centered.x * columns);
+    float columnSeed = hash(columnIndex);
+    float speed = mix(0.3, 1.3, columnSeed);
+    float trail = mix(0.2, 0.8, hash(columnIndex + 42.0));
+
+    float flow = fract(u_time * speed + columnSeed);
+    float rowPosition = fract(centered.y + flow);
+
+    float head = smoothstep(0.0, 0.1, rowPosition) * smoothstep(1.0, 0.85, rowPosition);
+
+    float cellRows = 60.0;
+    vec2 cellUv = vec2(fract(centered.x * columns), fract(centered.y * cellRows));
+    float cellId = floor(centered.y * cellRows) + columnIndex * 131.0;
+    float glyphVal = glyph(cellUv, cellId);
+
+    float tail = pow(1.0 - rowPosition, 2.0) * trail;
+    float brightness = max(head, tail) * glyphVal;
+
+    vec3 color = vec3(0.0, 0.9, 0.2) * brightness;
+    outColor = vec4(color, 1.0);
+}`;
+
+function createShader(type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const info = gl.getShaderInfoLog(shader);
+        gl.deleteShader(shader);
+        throw new Error(info || "Shader compile error");
+    }
+    return shader;
+}
+
+function createProgram(vertex, fragment) {
+    const program = gl.createProgram();
+    gl.attachShader(program, vertex);
+    gl.attachShader(program, fragment);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const info = gl.getProgramInfoLog(program);
+        gl.deleteProgram(program);
+        throw new Error(info || "Program link error");
+    }
+    return program;
+}
+
+const vertexShader = createShader(gl.VERTEX_SHADER, vertexSource);
+const fragmentShader = createShader(gl.FRAGMENT_SHADER, fragmentSource);
+const program = createProgram(vertexShader, fragmentShader);
+
+const positionBuffer = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([
+        -1, -1,
+        1, -1,
+        -1, 1,
+        -1, 1,
+        1, -1,
+        1, 1,
+    ]),
+    gl.STATIC_DRAW,
+);
+
+const positionLocation = gl.getAttribLocation(program, "a_position");
+const resolutionLocation = gl.getUniformLocation(program, "u_resolution");
+const timeLocation = gl.getUniformLocation(program, "u_time");
+
+function resizeCanvas() {
     const { width, height } = canvas.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
-
     canvas.width = Math.round(width * dpr);
     canvas.height = Math.round(height * dpr);
-
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-    return { width, height };
+    gl.viewport(0, 0, canvas.width, canvas.height);
 }
 
-// Matrix Rain Animation
-function matrixRain(
-    canvasId,
-    {
-        speedFactor = 0.9,
-        color = "#0F0",
-        opacity = 0.05,
-        fontSize = 16,
-        delayFactor = 2,
-        fps = 30,
-    },
-) {
-    const canvas = document.getElementById(canvasId);
-    const ctx = canvas.getContext("2d");
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
 
-    let canvasWidth = 0;
-    let canvasHeight = 0;
-    let columns = 0;
-    let drops = [];
-    let delays = [];
+function render(timestamp) {
+    if (isPaused()) {
+        requestAnimationFrame(render);
+        return;
+    }
 
-    const updateCanvasMetrics = () => {
-        const { width, height } = resizeCanvas(canvas, ctx);
-        canvasWidth = width;
-        canvasHeight = height;
-        columns = Math.floor(canvasWidth / fontSize);
-        drops = new Array(columns).fill(0);
-        delays = new Array(columns).fill(0); // Delay timers for each column
-    };
+    gl.useProgram(program);
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.enableVertexAttribArray(positionLocation);
+    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
 
-    // Set initial canvas size
-    updateCanvasMetrics();
-    window.addEventListener("resize", updateCanvasMetrics);
+    gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
 
-    const frameInterval = 1000 / fps;
-    let lastFrameTime = 0;
+    const time = (timestamp - animationState.pauseOffset) * 0.001;
+    gl.uniform1f(timeLocation, time);
 
-    const drawMatrix = (timestamp) => {
-        if (isPaused()) {
-            requestAnimationFrame(drawMatrix);
-            return;
-        }
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
 
-        if (timestamp - lastFrameTime < frameInterval) {
-            requestAnimationFrame(drawMatrix);
-            return;
-        }
-        lastFrameTime = timestamp;
-
-        // Clear the canvas with a trailing effect
-        ctx.fillStyle = `rgba(0, 0, 0, ${opacity})`;
-        ctx.fillRect(0, 0, canvasWidth, canvasHeight);
-
-        // Set text style
-        ctx.fillStyle = color;
-        ctx.font = `${fontSize}px monospace`;
-
-        for (let i = 0; i < drops.length; i++) {
-            const text = characters[Math.floor(Math.random() * characters.length)];
-            const x = i * fontSize;
-            const y = drops[i] * fontSize;
-
-            ctx.fillText(text, x, y);
-
-            // Move the drop down based on delay
-            if (delays[i] <= 0) {
-                drops[i] += 1; // Move down one step
-                delays[i] = Math.random() * (delayFactor / speedFactor); // Reset delay with layer-specific delayFactor
-            } else {
-                delays[i] -= 1; // Reduce delay
-            }
-
-            // Reset drop to the top randomly
-            if (y > canvasHeight && Math.random() > 0.975) {
-                drops[i] = 0; // Reset to the top
-            }
-        }
-
-        requestAnimationFrame(drawMatrix);
-    };
-
-    drawMatrix();
-    return canvas;
+    requestAnimationFrame(render);
 }
 
-
-
-// Matrix Overlay Animation
-function matrixOverlay(
-    canvasId,
-    {
-        fontSize = 16,
-        color = "rgba(255, 255, 255, 0.8)",
-        blinkSpeed = 400,
-        fps = 20,
-    },
-) {
-    const canvas = document.getElementById(canvasId);
-    const ctx = canvas.getContext("2d");
-
-    let canvasWidth = 0;
-    let canvasHeight = 0;
-
-    const updateCanvasMetrics = () => {
-        const { width, height } = resizeCanvas(canvas, ctx);
-        canvasWidth = width;
-        canvasHeight = height;
-    };
-
-    // Set initial canvas size
-    updateCanvasMetrics();
-    window.addEventListener("resize", updateCanvasMetrics);
-
-    const frameInterval = 1000 / fps;
-    let lastFrameTime = 0;
-    let lastBlinkTime = 0;
-
-    const drawOverlay = (timestamp) => {
-        if (isPaused()) {
-            requestAnimationFrame(drawOverlay);
-            return;
-        }
-
-        if (timestamp - lastFrameTime < frameInterval) {
-            requestAnimationFrame(drawOverlay);
-            return;
-        }
-        lastFrameTime = timestamp;
-
-        if (timestamp - lastBlinkTime >= blinkSpeed) {
-            lastBlinkTime = timestamp;
-            ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-            ctx.fillStyle = color;
-            ctx.font = `${fontSize}px monospace`;
-
-            // Draw random characters at random positions
-            for (let i = 0; i < 10; i++) {
-                const text = characters[Math.floor(Math.random() * characters.length)];
-                const x = Math.random() * canvasWidth;
-                const y = Math.random() * canvasHeight;
-
-                ctx.fillText(text, x, y);
-            }
-        }
-
-        requestAnimationFrame(drawOverlay);
-    };
-
-    drawOverlay();
-    return canvas;
-}
-
-function toggleBlurWithAnimation(canvasId, interval = 1000) {
-    const canvas = document.getElementById(canvasId);
-    let lastTime = 0; // Tracks the last time the blur was toggled
-    let isBlurred = false;
-
-    const toggleBlur = (timestamp) => {
-        if (isPaused()) {
-            requestAnimationFrame(toggleBlur);
-            return;
-        }
-
-        // Check if enough time has passed since the last toggle
-        if (timestamp - lastTime >= interval) {
-            lastTime = timestamp; // Update the last toggle time
-            isBlurred = !isBlurred; // Toggle blur state
-            if (isBlurred) {
-                canvas.classList.add("blur");
-            } else {
-                canvas.classList.remove("blur");
-            }
-        }
-
-        requestAnimationFrame(toggleBlur); // Schedule the next frame
-    };
-
-    requestAnimationFrame(toggleBlur); // Start the animation
-}
+requestAnimationFrame(render);
 
 window.addEventListener("keydown", (event) => {
     const key = event.key?.toLowerCase();
@@ -221,12 +180,3 @@ window.addEventListener("keydown", (event) => {
 window.addEventListener("click", () => {
     togglePause();
 });
-
-// Start animations
-matrixRain("matrixCanvas1", { speedFactor: 0.9, fontSize: 8, delayFactor: 1, fps: 30 });  // Faster updates
-matrixRain("matrixCanvas2", { speedFactor: 0.6, fontSize: 12, delayFactor: 6, fps: 30 }); // Balanced speed
-matrixRain("matrixCanvas3", { speedFactor: 0.8, fontSize: 12, delayFactor: 4, fps: 24 }); // Slower, dramatic effect
-
-matrixOverlay("overlayCanvas", { fontSize: 12, blinkSpeed: 400, fps: 15 });
-// Call the function to toggle blur
-toggleBlurWithAnimation("overlayCanvas", 3000); // Toggle blur every 3 seconds

--- a/matrix.js
+++ b/matrix.js
@@ -108,9 +108,9 @@ void main() {
     float aspect = u_resolution.x / u_resolution.y;
     vec2 centered = vec2(uv.x * aspect, uv.y);
 
-    float farLayer = layerRain(centered * vec2(1.04, 1.0), 120.0, 95.0, 0.2, 0.7, 0.35, 19.0, 0.0);
-    float midLayer = layerRain(centered * vec2(1.02, 1.0), 90.0, 70.0, 0.5, 1.0, 0.65, 7.0, 1.0);
-    float nearLayer = layerRain(centered, 70.0, 50.0, 0.7, 1.8, 1.0, 0.0, 0.0);
+    float farLayer = layerRain(centered * vec2(1.04, 1.0), 120.0, 95.0, 0.08, 0.35, 0.35, 19.0, 0.0);
+    float midLayer = layerRain(centered * vec2(1.02, 1.0), 90.0, 70.0, 0.18, 0.55, 0.65, 7.0, 1.0);
+    float nearLayer = layerRain(centered, 70.0, 50.0, 0.25, 0.8, 1.0, 0.0, 0.0);
 
     vec3 farColor = vec3(0.0, 0.6, 0.15) * farLayer;
     vec3 midColor = vec3(0.0, 0.8, 0.2) * midLayer;

--- a/matrix.js
+++ b/matrix.js
@@ -9,6 +9,12 @@ if (!gl) {
     throw new Error("WebGL2 not supported");
 }
 
+// Matrix Rain Characters
+const latinChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()-_=+[]{}|;:',.<>?/`~¡™£¢∞§¶•ªº–≠œ∑´®†¥¨ˆøπ“‘åß∂ƒ©˙∆˚¬Ω≈ç√∫˜µ≤≥÷";
+const japaneseChars = "アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをん一二三四五六七八九十零";
+const matrixChars = latinChars + japaneseChars;
+const characters = matrixChars.split("");
+
 const animationState = {
     paused: false,
     pauseOffset: 0,
@@ -40,6 +46,9 @@ precision highp float;
 
 uniform vec2 u_resolution;
 uniform float u_time;
+uniform sampler2D u_glyphAtlas;
+uniform vec2 u_atlasGrid;
+uniform float u_glyphCount;
 
 out vec4 outColor;
 
@@ -51,12 +60,11 @@ float hash(vec2 p) {
     return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
 }
 
-float glyph(vec2 cellUv, float seed) {
-    vec2 grid = floor(cellUv * vec2(5.0, 7.0));
-    float index = grid.x + grid.y * 5.0;
-    float bit = step(0.5, hash(vec2(index, seed)));
-    float edge = smoothstep(0.0, 0.08, min(min(cellUv.x, cellUv.y), min(1.0 - cellUv.x, 1.0 - cellUv.y)));
-    return bit * edge;
+float glyphAlpha(vec2 cellUv, float glyphIndex) {
+    float col = mod(glyphIndex, u_atlasGrid.x);
+    float row = floor(glyphIndex / u_atlasGrid.x);
+    vec2 atlasUv = (vec2(col, row) + cellUv) / u_atlasGrid;
+    return texture(u_glyphAtlas, atlasUv).r;
 }
 
 void main() {
@@ -65,6 +73,7 @@ void main() {
     vec2 centered = vec2(uv.x * aspect, uv.y);
 
     float columns = 80.0;
+    float rows = 60.0;
     float columnIndex = floor(centered.x * columns);
     float columnSeed = hash(columnIndex);
     float speed = mix(0.3, 1.3, columnSeed);
@@ -75,13 +84,13 @@ void main() {
 
     float head = smoothstep(0.0, 0.1, rowPosition) * smoothstep(1.0, 0.85, rowPosition);
 
-    float cellRows = 60.0;
-    vec2 cellUv = vec2(fract(centered.x * columns), fract(centered.y * cellRows));
-    float cellId = floor(centered.y * cellRows) + columnIndex * 131.0;
-    float glyphVal = glyph(cellUv, cellId);
+    vec2 cellUv = vec2(fract(centered.x * columns), fract(centered.y * rows));
+    float cellId = floor(centered.y * rows) + columnIndex * 131.0;
+    float glyphIndex = floor(hash(cellId) * u_glyphCount);
+    float glyph = glyphAlpha(cellUv, glyphIndex);
 
     float tail = pow(1.0 - rowPosition, 2.0) * trail;
-    float brightness = max(head, tail) * glyphVal;
+    float brightness = max(head, tail) * glyph;
 
     vec3 color = vec3(0.0, 0.9, 0.2) * brightness;
     outColor = vec4(color, 1.0);
@@ -112,6 +121,37 @@ function createProgram(vertex, fragment) {
     return program;
 }
 
+function createGlyphAtlas(glyphs) {
+    const glyphSize = 32;
+    const columns = 16;
+    const rows = Math.ceil(glyphs.length / columns);
+    const atlasCanvas = document.createElement("canvas");
+    atlasCanvas.width = columns * glyphSize;
+    atlasCanvas.height = rows * glyphSize;
+
+    const ctx = atlasCanvas.getContext("2d");
+    ctx.clearRect(0, 0, atlasCanvas.width, atlasCanvas.height);
+    ctx.fillStyle = "white";
+    ctx.font = "24px monospace";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    glyphs.forEach((glyph, index) => {
+        const x = (index % columns) * glyphSize + glyphSize / 2;
+        const y = Math.floor(index / columns) * glyphSize + glyphSize / 2;
+        ctx.fillText(glyph, x, y);
+    });
+
+    return {
+        canvas: atlasCanvas,
+        columns,
+        rows,
+        glyphCount: glyphs.length,
+    };
+}
+
+const atlas = createGlyphAtlas(characters);
+
 const vertexShader = createShader(gl.VERTEX_SHADER, vertexSource);
 const fragmentShader = createShader(gl.FRAGMENT_SHADER, fragmentSource);
 const program = createProgram(vertexShader, fragmentShader);
@@ -134,6 +174,24 @@ gl.bufferData(
 const positionLocation = gl.getAttribLocation(program, "a_position");
 const resolutionLocation = gl.getUniformLocation(program, "u_resolution");
 const timeLocation = gl.getUniformLocation(program, "u_time");
+const atlasGridLocation = gl.getUniformLocation(program, "u_atlasGrid");
+const glyphCountLocation = gl.getUniformLocation(program, "u_glyphCount");
+const glyphAtlasLocation = gl.getUniformLocation(program, "u_glyphAtlas");
+
+const glyphTexture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, glyphTexture);
+gl.texImage2D(
+    gl.TEXTURE_2D,
+    0,
+    gl.R8,
+    gl.RED,
+    gl.UNSIGNED_BYTE,
+    atlas.canvas,
+);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
 function resizeCanvas() {
     const { width, height } = canvas.getBoundingClientRect();
@@ -158,6 +216,12 @@ function render(timestamp) {
     gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
 
     gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+    gl.uniform2f(atlasGridLocation, atlas.columns, atlas.rows);
+    gl.uniform1f(glyphCountLocation, atlas.glyphCount);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, glyphTexture);
+    gl.uniform1i(glyphAtlasLocation, 0);
 
     const time = (timestamp - animationState.pauseOffset) * 0.001;
     gl.uniform1f(timeLocation, time);


### PR DESCRIPTION
### Motivation
- Move the Matrix rain effect from a CPU-driven multi-canvas 2D implementation to a GPU-driven WebGL2 shader for smoother, higher-performance rendering.
- Simplify the page to a single canvas and provide a visible fallback/status when WebGL2 is unavailable.

### Description
- Rewrote `matrix.js` to use WebGL2: added GLSL `vertexSource` and `fragmentSource` shaders, shader compilation and program linking, attribute/uniform setup, and a single GPU-driven draw loop using `requestAnimationFrame`.
- Replaced the multi-layer canvases in `index.html` with a single `<canvas id="matrixCanvas">` and a `#status` element, and updated metadata and styles to reflect the WebGL implementation.
- Updated `README.md` to document the WebGL2/GPU approach and expose shader-based customization points like `columns`, `cellRows`, `speed`, and `color`.
- Implemented pause handling with `animationState.pauseOffset` so toggling pause preserves animation timing.

### Testing
- Started a local static server with `python -m http.server 8000` and ran a Playwright script to open `http://127.0.0.1:8000/` and capture a screenshot; the script produced `artifacts/matrix-webgl.png` successfully.
- No unit tests were added for this front-end rendering change; validation was performed via the automated page load and screenshot capture described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978e42b5b14832a99d06c882fbdb3dc)